### PR TITLE
feat #2056: add `xesam:url` field for MPRIS

### DIFF
--- a/src/electron/mpris.js
+++ b/src/electron/mpris.js
@@ -35,6 +35,7 @@ export function createMpris(window) {
       'xesam:title': metadata.title,
       'xesam:album': metadata.album,
       'xesam:artist': metadata.artist.split(','),
+      'xesam:url': metadata.url,
     };
   });
 

--- a/src/utils/Player.js
+++ b/src/utils/Player.js
@@ -612,6 +612,7 @@ export default class {
       ],
       length: this.currentTrackDuration,
       trackId: this.current,
+      url: '/trackid/' + track.id,
     };
 
     navigator.mediaSession.metadata = new window.MediaMetadata(metadata);


### PR DESCRIPTION
chore: do not use fuo scheme, only netease music id is preserved

fix: lint prettier error